### PR TITLE
Debug scraper initialization error on render

### DIFF
--- a/scraper.js
+++ b/scraper.js
@@ -9,7 +9,17 @@ class NameGrepScraper {
   async init() {
     console.log('Launching headless browser...');
     this.browser = await chromium.launch({
-      headless: true
+      headless: true,
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+        '--disable-accelerated-2d-canvas',
+        '--no-first-run',
+        '--no-zygote',
+        '--single-process',
+        '--disable-gpu'
+      ]
     });
     
     const context = await this.browser.newContext({


### PR DESCRIPTION
Add Render-compatible Chromium launch arguments to `NameGrepScraper.init` to resolve a browser initialization error.

---
<a href="https://cursor.com/background-agent?bcId=bc-65708fb7-e389-44df-88f1-6495d4026ba6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-65708fb7-e389-44df-88f1-6495d4026ba6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

