### PR TITLE
Scrape website with playwright

### DIFF
--- a/install-playwright.sh
+++ b/install-playwright.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Install Playwright browsers for deployment
+echo "Installing Playwright browsers..."
+npx playwright install --with-deps chromium
+
+echo "Playwright installation complete!"
+echo "You can now run your scraper with: node scraper.js"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "api.js",
   "scripts": {
     "start": "node api.js",
-    "build": "npx playwright install chromium",
+    "build": "npx playwright install --with-deps chromium",
+    "postinstall": "npx playwright install --with-deps chromium",
     "test": "node scraper.js",
     "api": "node api.js",
     "dev": "node api.js",

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,7 @@ services:
   - type: web
     name: namegrep-scraper
     env: node
-    buildCommand: npm ci && npx playwright install chromium
+    buildCommand: npm ci && npx playwright install --with-deps chromium
     startCommand: npm run start
     envVars:
       - key: NODE_ENV


### PR DESCRIPTION
Fix Playwright browser installation on Render by updating build commands and adding a `postinstall` script to include system dependencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-da0accd1-1332-40ae-8665-4635ad346d5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da0accd1-1332-40ae-8665-4635ad346d5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

